### PR TITLE
Fix rewrite rule

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
 Plugin Name: Private Files (MPH)
 Description: Upload files that are only accessable to logged in users.
 Author: Matthew Haines-Young
-Version: 1.0.5
+Version: 1.0.6
 Author URI: http://www.matth.eu
 */
 

--- a/plugin.php
+++ b/plugin.php
@@ -162,8 +162,12 @@ class Mattheu_Private_Files {
 
 	function rewrite_rules() {
 
+		$uploads = wp_upload_dir();
+		$base_url = parse_url( $uploads['baseurl'] );
+		$base_url = trim( $base_url['path'], ' /' );
+
 		hm_add_rewrite_rule( array(
-			'regex' => '^content/uploads/private-files/([^*]+)/([^*]+)?$',
+			'regex' => '^'.$base_url.'/private-files/([^*]+)/([^*]+)?$',
 			'query' => 'file_id=$matches[1]&file_name=$matches[2]',
 			'request_method' => 'get',
 			'request_callback' => array( $this, 'rewrite_callback' )

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Private Media ===
 Contributors: mattheu
 Tags: private, media, files
-Requires at least: 3.5
-Tested up to: 3.5
-Stable tag: 0.1
+Requires at least: 4.5
+Tested up to: 4.7
+Stable tag: 1.0.6
 
 Make files in the WordPress media library private. These are only accessible to logged in users.
 
@@ -23,3 +23,9 @@ Access to Private files attachment pages in the front end is restricted. Will re
 
 * Install & Activate the plugin.
 * Edit an attachment, and check the private files option to set an attachment as private.
+
+== Changelog ==
+
+= 1.0.6 =
+* WordPress 4.7 compatibility
+* Fix the rewrite rule to use the correct base url


### PR DESCRIPTION
Fix rewrite rule so that it uses the correct base url and works in the latest WordPress 4.7